### PR TITLE
Speak slowly

### DIFF
--- a/addon/globalPlugins/clipboardEnhancement/__init__.py
+++ b/addon/globalPlugins/clipboardEnhancement/__init__.py
@@ -143,6 +143,17 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	def script_repeatSpoken(self, gesture):
 		ui.message(self.spoken)
 
+	@scriptHandler.script(
+		description=_("使用较慢的语速和重读单词重复刚听到的内容"),
+	)
+	def script_speakSlowly(self, gesture):
+		sequence = []
+		sequence.append(speech.commands.RateCommand(offset=-30))
+		for text in self.spoken.split():
+			sequence.append(text)
+			sequence.append(speech.commands.EndUtteranceCommand())
+		self.oldSpeak(sequence)
+
 	def newSpeak(self, sequence, *args, **kwargs):
 		data = ""
 		if isinstance(sequence, str):

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,7 @@
 | 追加刚听到的内容到剪贴板 | NVDA+Alt+d | NVDA+Alt+d |
 | 追加已选择的内容到剪贴板 | NVDA+Alt+a | NVDA+Alt+a |
 | 重复朗读刚听到的内容 | 未分配 | 未分配 |
+| 使用较慢的语速和重读单词重复刚听到的内容 | 未分配 | 未分配 |
 | 剪贴板第一行 | ctrl+小键盘 斜杠 | NVDA+alt+shift+上光标 |
 | 剪贴板最后一行 | ctrl+小键盘 星号 | NVDA+alt+shift+下光标 |
 | 剪贴板向上十行 | ctrl+小键盘 加号 | NVDA+alt+shift+上翻页 |


### PR DESCRIPTION
添加了一个新特性，用户可使用一个手势让 NVDA 以更慢的语速、重读单词重复刚刚说出的内容。

这个新特性，对于那些经常阅读文献，尤其是外语文献的中国人非常的有用。

这项功能的代码位于 __init__.py 中，设计方案如下：

1. 定义了一个新 script，允许用户给该功能分配一个手势；
2. 产生一个新的语音序列 `sequence`；
3. 在新语音序列 `sequence` 的开头插入一个 `RateCommand` 语音命令以降低语速，目前是降低 30；
4. 从 `self.spoken` 中获取上一次朗读的内容，并对此进行单词拆分，将拆出来的单词追加到 `sequence` 之中，紧随其后追加一个 EndUtteranceCommand` 语音命令，以使语音合成器暂停；
5. 最后，通过 `self.oldSpeak(sequence)` 将语音序列传送到语音合成器， `self.oldSpeak` 是我们插件内保存了 `speech.speech.speak` 调用对象的变量，这样就不会再次被我们的钩子机制拦截。

除此之外，我还更新了 README.MD 文件。
