### PR TITLE
修复 .vscode\settings.json 中对 NVDA 源代码的路径引用。

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,9 +8,9 @@
     "python.linting.flake8Enabled": true,
     "python.linting.pylintEnabled": false,
     "python.autoComplete.extraPaths": [
-        "../nvda/source",
-        "../nvda/miscDeps/python"
-        ],	
+        "${workspaceFolder}/../nvda/source", // NVDA 源代码应位于此工作区所在文件夹的父文件夹。
+        "${workspaceFolder}/../nvda/miscDeps/python"
+    ],
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "editor.insertSpaces": false,
@@ -18,8 +18,8 @@
         "reportUndefinedVariable": "none"
     },
     "python.analysis.extraPaths": [
-        "../nvda/source",
-        "../nvda/miscDeps/python"
+        "${workspaceFolder}/../nvda/source",
+        "${workspaceFolder}/../nvda/miscDeps/python"
     ],
-    "python.defaultInterpreterPath": "../nvda/.venv/scripts/python.exe"
+    "python.defaultInterpreterPath": "${workspaceFolder}/../nvda/.venv/scripts/python.exe"
 }


### PR DESCRIPTION
在加载 Python 虚拟环境时遇到了错误理解 .vscode\settings.json 中设置的 NVDA 源代码目录的错误。

```
2023-06-25 19:32:14.846 [warning] Identifier for virt-virtualenv failed to identify ..\nvda\.venv\scripts\python.exe [Error: ENOENT: no such file or directory, scandir 'C:\Users\UserName\AppData\Local\Programs\nvda\.venv\scripts'] {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'scandir',
  path: 'C:\\Users\\UserName\\AppData\\Local\\Programs\\nvda\\.venv\\scripts'
}
``` 

解决方案：在 settings.json 中引用的路径前增加工作区环境变量。