### PR TITLE
Do not assign the patched speak function to None

### DIFF
--- a/addon/globalPlugins/clipboardEnhancement/__init__.py
+++ b/addon/globalPlugins/clipboardEnhancement/__init__.py
@@ -737,7 +737,11 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		self.monitor.Stop()
 		self.monitor = None
 		speechModule.speak = self.oldSpeak
-		self.oldSpeak = None
+		# Do not set self.oldSpeak to None.
+		# Since many add-ons can patch speech.speak and since the order in which patching and unpatching is not
+		# well established, we may end up speech.speak restored to None (e.g. clipboardEnhancement and
+		# baiduTranslation)
+		# self.oldSpeak = None
 		if self.editor:
 			self.editor.isExit = True
 			self.editor.Destroy()


### PR DESCRIPTION
### Steps to reproduce the issue
* install both Baidu Translation and and Clipboard Enhancement and restart
* Press NVDA+control+f3 to reload the add-ons

### Result
NVDA cannot speak anymore

### Probable explanation
When multiple add-ons patch `speech.speak`, we cannot consider that we have a reliable order to ensure that add-on 1 patches first and unpatch last with respect to add-on 2.

### Solution
Do not set the patch function variable to `None`. when therminating the add-on.
We probably end up with not all speak functions being unpatched, but that still much better than having an error on each speak call.

### Note
With NVDA 2024.2, there will be an extension point for the speak function which will be much cleaner.



